### PR TITLE
Correct Spanish translation of Release

### DIFF
--- a/sphinx/locale/es/LC_MESSAGES/sphinx.po
+++ b/sphinx/locale/es/LC_MESSAGES/sphinx.po
@@ -851,7 +851,7 @@ msgstr "Enlace permanente a esta tabla"
 
 #: sphinx/writers/latex.py:361
 msgid "Release"
-msgstr "Publicación"
+msgstr "Versión"
 
 #: sphinx/writers/latex.py:427
 msgid "page"


### PR DESCRIPTION
In this case, release should be translated to "versión", not to "publicación", since it matches the context more accurately.

See that version is used in French, versió in Catalan, versão in Portuguese from Portugal and versiune in Romanian. In other romance languages like Italian, the word release is used untranslated.